### PR TITLE
Revert "chore: npm publishのci test"

### DIFF
--- a/.changeset/poor-chicken-notice.md
+++ b/.changeset/poor-chicken-notice.md
@@ -1,5 +1,0 @@
----
-"@elecdeer/event-flow": patch
----
-
-npm publish CI test.


### PR DESCRIPTION
Reverts elecdeer/discord-inquirer#9
release CIが動作することを確認できたのでrevert