### PR TITLE
fix: monorepo内のパッケージをignoreに追加

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -11,28 +11,30 @@ updates:
       interval: "weekly"
     open-pull-requests-limit: 10
     versioning-strategy: "auto"
+    ignore:
+      - dependency-name: "@monorepo/eslint-config"
+      - dependency-name: "@monorepo/tsconfig"
     labels:
       - "dependencies"
       - "root"
 
-  - package-ecosystem: "npm"
-    directory: "/packages/inquirer"
-    schedule:
-      interval: "weekly"
-    open-pull-requests-limit: 10
-    versioning-strategy: "auto"
-    labels:
-      - "dependencies"
-      - "inquirer"
-
-  - package-ecosystem: "npm"
-    directory: "/packages/discordjs-adaptor"
-    schedule:
-      interval: "weekly"
-    open-pull-requests-limit: 10
-    versioning-strategy: "auto"
-    labels:
-      - "dependencies"
-      - "discordjs-adaptor"
-
+#  - package-ecosystem: "npm"
+#    directory: "/packages/inquirer"
+#    schedule:
+#      interval: "weekly"
+#    open-pull-requests-limit: 10
+#    versioning-strategy: "auto"
+#    labels:
+#      - "dependencies"
+#      - "inquirer"
+#
+#  - package-ecosystem: "npm"
+#    directory: "/packages/discordjs-adaptor"
+#    schedule:
+#      interval: "weekly"
+#    open-pull-requests-limit: 10
+#    versioning-strategy: "auto"
+#    labels:
+#      - "dependencies"
+#      - "discordjs-adaptor"
 


### PR DESCRIPTION
dependabotが@monorepo/*を見つけられずエラーになる