### PR TITLE
refactor: 各種selectComponentHookの最大最小指定数をhook呼び出し側に移動

### DIFF
--- a/packages/example/src/propmt/selectsPrompt.ts
+++ b/packages/example/src/propmt/selectsPrompt.ts
@@ -53,6 +53,7 @@ export const selectsPrompt: Prompt<{
         answer("channelSelected", selected);
         console.log("channel selected", selected);
       },
+      maxValues: 2,
     });
 
   const [userResult, UserSelectComponent] = useUserSelectComponent({
@@ -60,6 +61,7 @@ export const selectsPrompt: Prompt<{
       answer("userSelected", selected);
       console.log("user selected", selected);
     },
+    maxValues: 2,
   });
 
   const [roleResult, RoleSelectComponent] = useRoleSelectComponent({
@@ -67,6 +69,7 @@ export const selectsPrompt: Prompt<{
       answer("roleSelected", selected);
       console.log("role selected", selected);
     },
+    maxValues: 2,
   });
 
   const [mentionableResult, MentionableSelectComponent] =
@@ -75,6 +78,7 @@ export const selectsPrompt: Prompt<{
         answer("mentionableSelected", selected);
         console.log("mentionable selected", selected);
       },
+      maxValues: 2,
     });
 
   return {
@@ -112,26 +116,10 @@ export const selectsPrompt: Prompt<{
     ],
     components: [
       Row(Select({})()),
-      Row(
-        ChannelSelectComponent({
-          maxValues: 2,
-        })()
-      ),
-      Row(
-        UserSelectComponent({
-          maxValues: 2,
-        })()
-      ),
-      Row(
-        RoleSelectComponent({
-          maxValues: 2,
-        })()
-      ),
-      Row(
-        MentionableSelectComponent({
-          maxValues: 2,
-        })()
-      ),
+      Row(ChannelSelectComponent()),
+      Row(UserSelectComponent()),
+      Row(RoleSelectComponent()),
+      Row(MentionableSelectComponent()),
     ],
   };
 };

--- a/packages/inquirer/src/hook/render/useChannelSelectComponent.ts
+++ b/packages/inquirer/src/hook/render/useChannelSelectComponent.ts
@@ -5,7 +5,6 @@ import { useCustomId } from "../state/useCustomId";
 import { useState } from "../state/useState";
 
 import type {
-  AdaptorPartialChannel,
   AdaptorChannelTypes,
   ChannelSelectComponentBuilder,
   AdaptorPartialNonThreadChannel,
@@ -55,14 +54,35 @@ export type TypeSpecifiedChannel<T extends AdaptorChannelTypes> = {
   };
 }[T];
 
+export type UseChannelSelectComponentParams<
+  ChannelTypes extends AdaptorChannelTypes = AdaptorChannelTypes
+> = {
+  channelTypes?: ChannelTypes[];
+  onSelected?: (selected: ChannelSelectResultValue<ChannelTypes>[]) => void;
+  minValues?: number;
+  maxValues?: number;
+};
+
 export type UseChannelSelectComponentResult<
   ChannelTypes extends AdaptorChannelTypes = AdaptorChannelTypes
 > = [
   selectResult: ChannelSelectResultValue<ChannelTypes>[],
   ChannelSelect: ChannelSelectComponentBuilder<{
     customId: string;
+    minValues: number | undefined;
+    maxValues: number | undefined;
   }>
 ];
+
+export type UseChannelSingleSelectComponentParams<
+  ChannelTypes extends AdaptorChannelTypes = AdaptorChannelTypes
+> = {
+  channelTypes?: ChannelTypes[];
+  onSelected?: (
+    selected: ChannelSelectResultValue<ChannelTypes> | null
+  ) => void;
+  minValues?: 1;
+};
 
 export type UseChannelSingleSelectComponentResult<
   ChannelTypes extends AdaptorChannelTypes = AdaptorChannelTypes
@@ -70,6 +90,7 @@ export type UseChannelSingleSelectComponentResult<
   selectResult: ChannelSelectResultValue<ChannelTypes> | null,
   ChannelSelect: ChannelSelectComponentBuilder<{
     customId: string;
+    minValues: 1 | undefined;
     maxValues: 1;
   }>
 ];
@@ -77,10 +98,7 @@ export type UseChannelSingleSelectComponentResult<
 export const useChannelSelectComponent = <
   ChannelTypes extends AdaptorChannelTypes = AdaptorChannelTypes
 >(
-  params: {
-    channelTypes?: ChannelTypes[];
-    onSelected?: (selected: ChannelSelectResultValue<ChannelTypes>[]) => void;
-  } = {}
+  params: UseChannelSelectComponentParams<ChannelTypes> = {}
 ): UseChannelSelectComponentResult<ChannelTypes> => {
   const customId = useCustomId("channelSelect");
 
@@ -111,6 +129,8 @@ export const useChannelSelectComponent = <
     ChannelSelect({
       customId,
       channelTypes: params.channelTypes,
+      minValues: params.minValues,
+      maxValues: params.maxValues,
     }),
   ];
 };
@@ -118,24 +138,16 @@ export const useChannelSelectComponent = <
 export const useChannelSingleSelectComponent = <
   ChannelTypes extends AdaptorChannelTypes = AdaptorChannelTypes
 >(
-  params: {
-    channelTypes?: ChannelTypes[];
-    onSelected?: (
-      selected: ChannelSelectResultValue<ChannelTypes> | null
-    ) => void;
-  } = {}
+  param: UseChannelSingleSelectComponentParams<ChannelTypes> = {}
 ): UseChannelSingleSelectComponentResult<ChannelTypes> => {
   const [selected, select] = useChannelSelectComponent({
-    channelTypes: params.channelTypes,
+    channelTypes: param.channelTypes,
     onSelected: (selected) => {
-      params.onSelected?.(selected[0] ?? null);
+      param.onSelected?.(selected[0] ?? null);
     },
+    minValues: param.minValues,
+    maxValues: 1,
   });
 
-  return [
-    selected[0] ?? null,
-    select({
-      maxValues: 1,
-    }),
-  ];
+  return [selected[0] ?? null, select];
 };

--- a/packages/inquirer/src/hook/render/useMentionableSelectComponent.ts
+++ b/packages/inquirer/src/hook/render/useMentionableSelectComponent.ts
@@ -13,6 +13,8 @@ export type UseMentionableSelectComponentResult = [
   selected: MentionableSelectValue[],
   MentionableSelect: MentionableSelectComponentBuilder<{
     customId: string;
+    minValues: number | undefined;
+    maxValues: number | undefined;
   }>
 ];
 
@@ -20,14 +22,24 @@ export type UseMentionableSingleSelectComponentResult = [
   selected: MentionableSelectValue | null,
   MentionableSelect: MentionableSelectComponentBuilder<{
     customId: string;
+    minValues: 1 | undefined;
     maxValues: 1;
   }>
 ];
 
+export type UseMentionableSelectComponentParams = {
+  onSelected?: (selected: MentionableSelectValue[]) => void;
+  minValues?: number;
+  maxValues?: number;
+};
+
+export type UseMentionableSingleSelectComponentParams = {
+  onSelected?: (selected: MentionableSelectValue | null) => void;
+  minValues?: 1;
+};
+
 export const useMentionableSelectComponent = (
-  params: {
-    onSelected?: (selected: MentionableSelectValue[]) => void;
-  } = {}
+  params: UseMentionableSelectComponentParams = {}
 ): UseMentionableSelectComponentResult => {
   const customId = useCustomId("mentionableSelect");
 
@@ -45,26 +57,23 @@ export const useMentionableSelectComponent = (
     selected,
     MentionableSelect({
       customId,
+      minValues: params.minValues,
+      maxValues: params.maxValues,
     }),
   ];
 };
 
 export const useMentionableSingleSelectComponent = (
-  params: {
-    onSelected?: (selected: MentionableSelectValue | null) => void;
-  } = {}
+  param: UseMentionableSingleSelectComponentParams = {}
 ): UseMentionableSingleSelectComponentResult => {
   const [selected, MentionableSelect] = useMentionableSelectComponent({
     onSelected: (selected) => {
       assert(selected.length <= 1);
-      params.onSelected?.(selected[0] ?? null);
+      param.onSelected?.(selected[0] ?? null);
     },
+    minValues: param.minValues,
+    maxValues: 1,
   });
 
-  return [
-    selected[0] ?? null,
-    MentionableSelect({
-      maxValues: 1,
-    }),
-  ];
+  return [selected[0] ?? null, MentionableSelect];
 };

--- a/packages/inquirer/src/hook/render/useRoleSelectComponent.ts
+++ b/packages/inquirer/src/hook/render/useRoleSelectComponent.ts
@@ -12,6 +12,8 @@ export type UseRoleSelectComponentResult = [
   selectedResult: AdaptorRole[],
   RoleSelect: RoleSelectComponentBuilder<{
     customId: string;
+    minValues: number | undefined;
+    maxValues: number | undefined;
   }>
 ];
 
@@ -19,14 +21,24 @@ export type UseRoleSingleSelectComponentResult = [
   selectedResult: AdaptorRole | null,
   RoleSelect: RoleSelectComponentBuilder<{
     customId: string;
+    minValues: 1 | undefined;
     maxValues: 1;
   }>
 ];
 
+export type UseRoleSelectComponentParams = {
+  onSelected?: (selected: AdaptorRole[]) => void;
+  minValues?: number;
+  maxValues?: number;
+};
+
+export type UseRoleSingleSelectComponentParams = {
+  onSelected?: (selected: AdaptorRole | null) => void;
+  minValues?: 1;
+};
+
 export const useRoleSelectComponent = (
-  params: {
-    onSelected?: (selected: AdaptorRole[]) => void;
-  } = {}
+  params: UseRoleSelectComponentParams = {}
 ): UseRoleSelectComponentResult => {
   const customId = useCustomId("roleSelect");
 
@@ -45,26 +57,23 @@ export const useRoleSelectComponent = (
     selected,
     RoleSelect({
       customId,
+      minValues: params.minValues,
+      maxValues: params.maxValues,
     }),
   ];
 };
 
 export const useRoleSingleSelectComponent = (
-  params: {
-    onSelected?: (selected: AdaptorRole | null) => void;
-  } = {}
+  param: UseRoleSingleSelectComponentParams = {}
 ): UseRoleSingleSelectComponentResult => {
   const [selected, Select] = useRoleSelectComponent({
     onSelected: (selected) => {
       assert(selected.length <= 1);
-      params.onSelected?.(selected[0] ?? null);
+      param.onSelected?.(selected[0] ?? null);
     },
+    minValues: param.minValues,
+    maxValues: 1,
   });
 
-  return [
-    selected[0] ?? null,
-    Select({
-      maxValues: 1,
-    }),
-  ];
+  return [selected[0] ?? null, Select];
 };

--- a/packages/inquirer/src/hook/render/useUserSelectComponent.ts
+++ b/packages/inquirer/src/hook/render/useUserSelectComponent.ts
@@ -13,6 +13,8 @@ export type UseUserSelectComponentResult = [
   selectResult: UserSelectResultValue[],
   UserSelect: UserSelectComponentBuilder<{
     customId: string;
+    minValues: number | undefined;
+    maxValues: number | undefined;
   }>
 ];
 
@@ -20,14 +22,24 @@ export type UseUserSingleSelectComponentResult = [
   selectResult: UserSelectResultValue | null,
   UserSelect: UserSelectComponentBuilder<{
     customId: string;
+    minValues: 1 | undefined;
     maxValues: 1;
   }>
 ];
 
+export type UseUserSelectComponentParams = {
+  onSelected?: (selected: UserSelectResultValue[]) => void;
+  minValues?: number;
+  maxValues?: number;
+};
+
+export type UseUserSingleSelectComponentParams = {
+  onSelected?: (selected: UserSelectResultValue | null) => void;
+  minValues?: 1;
+};
+
 export const useUserSelectComponent = (
-  param: {
-    onSelected?: (selected: UserSelectResultValue[]) => void;
-  } = {}
+  param: UseUserSelectComponentParams = {}
 ): UseUserSelectComponentResult => {
   const customId = useCustomId("userSelect");
 
@@ -46,26 +58,23 @@ export const useUserSelectComponent = (
     selected,
     UserSelect({
       customId,
+      minValues: param.minValues,
+      maxValues: param.maxValues,
     }),
   ];
 };
 
 export const useUserSingleSelectComponent = (
-  param: {
-    onSelected?: (selected: UserSelectResultValue | null) => void;
-  } = {}
+  param: UseUserSingleSelectComponentParams = {}
 ): UseUserSingleSelectComponentResult => {
   const [selected, Select] = useUserSelectComponent({
     onSelected: (selected) => {
       assert(selected.length <= 1);
       param.onSelected?.(selected[0] ?? null);
     },
+    minValues: param.minValues,
+    maxValues: 1,
   });
 
-  return [
-    selected[0] ?? null,
-    Select({
-      maxValues: 1,
-    }),
-  ];
+  return [selected[0] ?? null, Select];
 };


### PR DESCRIPTION
pagedのインターフェースと統一